### PR TITLE
GA 記法修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,5 +20,5 @@ jobs:
           username: ${{ secrets.FTP_USER }}
           password: ${{ secrets.FTP_PASSWORD }}
           server-dir: ./
-          local-dir: ./public
+          local-dir: ./public/
           exclude: ignore


### PR DESCRIPTION
- #7, #8 の GA は実行されたが、記法が誤っておりエラーになったので修正 → 正常に実行された


https://github.com/tomii9273/mahjong_takugumi/actions/runs/6568238798
> `Error: local-dir should be a folder (must end with /)`

## 参考
- #10