### PR TITLE
「1 対 1 のゲーム用」の項目を追加

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,6 +53,7 @@
         <li><a href="#long_game">長期戦用（全員と3回ずつ同卓）</a></li>
       </ul>
       <li><a href="#3ma">3人麻雀用</a></li>
+      <li><a href="#1vs1">1 対 1 のゲーム用</a></li>
       <li><a href="#code">Python コード</a></li>
     </ul>
 
@@ -407,6 +408,26 @@
         <a href="3ma/25taku_75nin_37sen.txt">25卓75人37戦</a><br />
       </dt>
     </dl>
+
+    <br />
+    <h2 id="1vs1">1 対 1 のゲーム用</h2>
+
+    <p>
+      1 対 1 で行うゲームやスポーツでは、以下のリンク先の方法で簡単に総当たり戦を組むことができます。<br />
+      <a href="https://www.ne.jp/asahi/office/okada/soft/souatari/help/help.html">https://www.ne.jp/asahi/office/okada/soft/souatari/help/help.html</a
+      ><br />
+      人数 (チーム数) が<b>偶数</b>の場合は<b>「n 人が同時並行で n / 2 戦を行うこと」を n-1 回行う</b>ことになります。<br />
+      <b>奇数</b>の場合は、1 多い偶数で総当たり戦を作成した後、選手番号 1 番を削除し、1 番と対戦する人を抜け番とする方法をとることで<br />
+      <b>「n - 1 人が同時並行で (n - 1) / 2 戦を行うこと」を n 回行う</b>ことになります (画像は 7 人の例です)。
+    </p>
+
+    <img src="images/1vs1_00.png" alt="1 対 1 での 7 人総当たり戦の例" width="40%" height="40%" />
+
+    <p>
+      <a href="souatari_sen_method.html">麻雀総当たり戦の卓組作成方法</a>
+      に記載した「円と点を使った方法」でも、以下のリンク先のようにして総当たり戦を組むことができます。<br />
+      <a href="https://salon-hiyake.hatenablog.com/entry/2014/08/14/091103">https://salon-hiyake.hatenablog.com/entry/2014/08/14/091103</a>
+    </p>
 
     <br />
     <h2 id="code">Python コード</h2>

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="ja">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -8,7 +8,7 @@
   <body bgcolor="#e0ffe0">
     <h1>麻雀大会用卓組表</h1>
 
-    <p>麻雀の大会やイベント等に使用できる卓組表（対戦表）の一覧です。</p>
+    <p>麻雀など、多人数で行うゲーム・スポーツの大会やイベント等に使用できる卓組表（対戦表）、およびその作成方法をまとめました。</p>
 
     <ul>
       <li>直接卓組表にリンクされているものに関しては、当サイトの作者が作成したものです。二次配布や改変を含め、ご自由にお使いください。</li>


### PR DESCRIPTION
## WHY

今後、このサイトを、麻雀以外の一般の n 人ゲームについて、n = 3, 4 以外についても、サイトやアルゴリズムや卓組を紹介する・(ないなら) 自作するものにしていきたい。
まずは、需要が大きそうな n = 2 (1 対 1 で行うゲーム) について行いたい。

## WHAT

1 対 1 の総当たり戦のアルゴリズム・作成ソフトは既にありそうであり、探したらいくつか見つかったので、[最も簡易に見えたもの](https://www.ne.jp/asahi/office/okada/soft/souatari/help/help.html)を紹介することにした。
プレイヤー数が奇数の場合についての言及がなかったので、それは記述した。
[総当たり戦卓組作成方法](https://tomii6614.web.fc2.com/souatari_sen_method.html)に記載済みの、円と点を使用した方法を書いていたサイトもあったので、[そのサイト](https://salon-hiyake.hatenablog.com/entry/2014/08/14/091103)も載せた。

また、header を上記「WHY」を反映したものに書き換えた。

## 参考

- 修正: #24