### PR TITLE
作成方法ページ・ソースコードの一覧の表を追加

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,7 @@
       </ul>
       <li><a href="#3ma">3人麻雀用</a></li>
       <li><a href="#1vs1">1 対 1 のゲーム用</a></li>
-      <li><a href="#code">Python コード</a></li>
+      <li><a href="#method_and_src">作成方法ページ・ソースコードの一覧</a></li>
     </ul>
 
     <br />
@@ -517,26 +517,84 @@
     </p>
 
     <br />
-    <h2 id="code">Python コード</h2>
-    <ul>
-      <li>卓組の作成に使用したPythonのコードをGitHub上に公開しています。まだ一部ですが、今後増やしていく予定です。</li>
-    </ul>
+    <h2 id="method_and_src">作成方法ページ・ソースコードの一覧</h2>
 
-    <dl>
-      <dt>
-        <br />
-        個人戦・4人チーム戦用<br />
-        4チーム戦用<br />
-        ペア戦用<br />
-        トリオ戦用<br />
-        <a href="https://github.com/tomii9273/takugumi_code/blob/master/souatarisen.py">総当たり戦用</a><br />
-        抜け番あり（人数が4の倍数でない場合）4戦＋調整1戦<br />
-        抜け番あり（人数が4の倍数でない場合）8戦＋調整1戦<br />
-        少人数用（14人以下）<br />
-        長期戦用（プレイヤーは他全員と3回ずつ同卓、n卓4n人(4n-1)回戦）<br />
-        3人麻雀用（総当たり戦）<br />
-      </dt>
-    </dl>
+    <p>各卓組の作成方法ページとソースコードへのリンクをまとめました。空欄は未作成のものです。</p>
+
+    <table border="1">
+      <tr align="left">
+        <th>種類</th>
+        <th>卓組</th>
+        <th>作成方法</th>
+        <th>コード</th>
+      </tr>
+      <tr align="left">
+        <td>個人戦・4人チーム戦用</td>
+        <td><a href="#kojin_sen">■</a></td>
+        <td><a href="kojin_sen_method.html">■</a></td>
+        <td></td>
+      </tr>
+      <tr align="left">
+        <td>4チーム戦用</td>
+        <td><a href="#4team_sen">■</a></td>
+        <td><a href="4team_sen_method.html">■</a></td>
+        <td></td>
+      </tr>
+      <tr align="left">
+        <td>ペア戦（2人チーム戦）用</td>
+        <td><a href="#pair_sen">■</a></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr align="left">
+        <td>トリオ戦（3人チーム戦）用</td>
+        <td><a href="#trio_sen">■</a></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr align="left">
+        <td>総当たり戦用</td>
+        <td><a href="#souatari_sen">■</a></td>
+        <td><a href="souatari_sen_method.html">■</a></td>
+        <td><a href="https://github.com/tomii9273/takugumi_code/blob/master/souatarisen.py">■</a></td>
+      </tr>
+      <tr align="left">
+        <td>抜け番あり（人数が4の倍数でない場合）1人4戦 合計5戦</td>
+        <td><a href="#nukeari_4and1_sen">■</a></td>
+        <td><a href="nukeari_4and1_sen_method.html">■</a></td>
+        <td></td>
+      </tr>
+      <tr align="left">
+        <td>抜け番あり（人数が4の倍数でない場合）1人8戦 合計9戦</td>
+        <td><a href="#nukeari_8and1_sen">■</a></td>
+        <td><a href="nukeari_8and1_sen_method.html">■</a></td>
+        <td></td>
+      </tr>
+      <tr align="left">
+        <td>少人数用（14人以下）</td>
+        <td><a href="#shouninzuu">■</a></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr align="left">
+        <td>長期戦用（全員と3回ずつ同卓）</td>
+        <td><a href="#long_game">■</a></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr align="left">
+        <td>3人麻雀用</td>
+        <td><a href="#3ma">■</a></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr align="left">
+        <td>1 対 1 のゲーム用</td>
+        <td>-</td>
+        <td><a href="#1vs1">■</a></td>
+        <td>-</td>
+      </tr>
+    </table>
 
     <br />
     <br />


### PR DESCRIPTION
## WHY

- 卓組の作成方法へのリンクが各項目に散らばっているので、まとまったものが欲しい
- 「Python コード」の項目の卓組種類名が古く、また (コードを公開しているのが 1 つしかないため) この項目を有効活用できていないので、改善したい

## WHAT

「Python コード」の項目を、卓組 (目次と同じ、ページ内リンク)・作成方法ページ・ソースコードへのリンクを種類ごとにまとめた表に置き換えた。
これを目次にしてしまおうかとも思ったが、目次の階層構造を維持できないため、そうはせずにページ最下部に作成した。

表の「空欄」は未作成 = 今後作成する予定のもの、「-」はもともと作りようのないもの、として使い分ける。

リンクをすべて踏んで、ミスがないことを確認。